### PR TITLE
fix(analyser): update file type classification filter

### DIFF
--- a/src/analyser.ts
+++ b/src/analyser.ts
@@ -113,7 +113,7 @@ export async function analyzeCodebase(
   const filteredFiles = relevantFiles.filter(file => {
     const relativePath = path.relative(projectPath, file);
     const fileType = classifyFileType(relativePath);
-    return ['Package'].includes(fileType);
+    return ['Plugin', 'Middleware', 'Package'].includes(fileType);
   });
 
   console.log(


### PR DESCRIPTION
Removed inadvertent commit to reduce files analysed to only package.json, this was done for local testing and should not have been pushed