### PR TITLE
feat: add support for gitignore file

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ content-sdk-migrate report \
 ### Options
 
 - `-p, --path <path>`: Path to the root of the JSS project (required)
+- `--gitignore <path>`: Path to a `.gitignore` file to use for file discovery
 - `--apiKey <key>`: API key for authentication (required unless `--debug`)
 - `-d, --debug`: Use local debug service (`http://localhost:7071`)
 - `-v, --verbose`: Verbose logging
@@ -68,6 +69,32 @@ content-sdk-migrate report \
 - `--intervalMs <number>`: Interval window in milliseconds (default safe value is used)
 
 Note: The CLI warns when throttle overrides are potentially unsafe.
+
+### How the .gitignore is used
+
+During file discovery, the CLI respects ignore rules to avoid scanning dependencies, build outputs, and other non-source files.
+
+- By default, it looks for a `.gitignore` at the project root specified by `--path` and applies its rules.
+- You can provide a different ignore file using `--gitignore <path>`. The path can be absolute or relative to the `--path` directory.
+- If the provided path does not exist, a warning is shown and the CLI falls back to built-in defaults only.
+
+Examples:
+
+```bash
+# Use the project's root .gitignore (default behavior)
+content-sdk-migrate report --path . --apiKey <api-key>
+
+# Use a custom ignore file located elsewhere
+content-sdk-migrate report --path . --apiKey <api-key> --gitignore ./configs/migrate.ignore
+
+# Provide an absolute path to the ignore file
+content-sdk-migrate report --path . --apiKey <api-key> --gitignore C:/work/myapp/.gitignore
+```
+
+Notes:
+
+- The CLI also applies a small set of sensible default ignores as a fallback (e.g., `node_modules`, build outputs, and common test fixture folders like `__tests__`).
+- The ignore rules are applied to the relative paths of discovered files using standard `.gitignore` semantics.
 
 ### Passing the API key via environment variables
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@think-fresh-digital/content-sdk-migrate",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@think-fresh-digital/content-sdk-migrate",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@think-fresh-digital/content-sdk-migrate",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "bin": {
     "content-sdk-migrate": "dist/index.js"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ program
     'Analyse a local codebase and generate a Content SDK migration report'
   )
   .option('-p, --path <path>', 'Path to the root of the JSS project')
+  .option('--gitignore <path>', 'Path to a .gitignore file to apply')
   .option('--apiKey <key>', 'API key for authentication', '')
   .option('-d, --debug', 'Enable debug mode', false)
   .option('-v, --verbose', 'Enable verbose output', false)
@@ -109,7 +110,8 @@ program
           maxConcurrent: options.maxConcurrent,
           intervalCap: options.intervalCap,
           intervalMs: options.intervalMs,
-        }
+        },
+        options.gitignore
       );
     } catch (error) {
       console.error(chalk.red('\nAnalysis failed:'));


### PR DESCRIPTION
Allow the path to the .gitignore file being used to be passed in the CLI while falling back to the default behaviour if not provided